### PR TITLE
inital support for user-selectable cursors

### DIFF
--- a/data/default_config.json
+++ b/data/default_config.json
@@ -2,6 +2,12 @@
 	"active_document" : "",
     "use_headerbar" : true,
     "use_highlight_proxy" : false,
+	"tool_cursors": {
+		"pen": "default",
+		"text": "text",
+		"eraser": "cell",
+		"select": "cross"
+	},
 	"colors" : 
 	[
 		{

--- a/data/preferences.glade
+++ b/data/preferences.glade
@@ -1,16 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.36.0 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
+  <object class="GtkImage" id="reset_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-delete</property>
+  </object>
   <object class="GtkDialog" id="preferences">
     <property name="can_focus">False</property>
     <property name="resizable">False</property>
     <property name="modal">True</property>
     <property name="destroy_with_parent">True</property>
     <property name="type_hint">dialog</property>
-    <child type="titlebar">
-      <placeholder/>
-    </child>
     <child internal-child="vbox">
       <object class="GtkBox">
         <property name="can_focus">False</property>
@@ -120,10 +122,40 @@
               <object class="GtkBox">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkLabel" id="filler2">
+                  <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkLabel" id="cursor_label">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Pen Cursor</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBoxText" id="pen_cursor">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_start">16</property>
+                        <property name="active">0</property>
+                        <items>
+                          <item id="cursor_default" translatable="yes">Default</item>
+                          <item id="cursor_cross" translatable="yes">Cross</item>
+                        </items>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -132,12 +164,14 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkCheckButton" id="use_headerbar">
-                    <property name="label" translatable="yes">Use headerbar</property>
+                  <object class="GtkLabel">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="draw_indicator">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="margin_bottom">10</property>
+                    <property name="label" translatable="yes">&lt;small&gt;&lt;span foreground="grey"&gt;The cursor that the pen tool should have&lt;/span&gt;&lt;/small&gt;</property>
+                    <property name="use_markup">True</property>
+                    <property name="wrap">True</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -153,6 +187,42 @@
               </packing>
             </child>
             <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkCheckButton" id="use_headerbar">
+                    <property name="label" translatable="yes">Use headerbar</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="filler2">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
@@ -165,24 +235,13 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">3</property>
+                <property name="position">4</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <child>
-                  <object class="GtkLabel" id="filler3">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
                 <child>
                   <object class="GtkCheckButton" id="use_highlight_proxy">
                     <property name="label" translatable="yes">Enable syntax highlighting</property>
@@ -194,6 +253,17 @@
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="filler3">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
@@ -201,7 +271,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">4</property>
+                <property name="position">5</property>
               </packing>
             </child>
             <child>
@@ -220,21 +290,6 @@ This increases startup time and may result in markdown rendering failing if &lt;
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">5</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">end</property>
-                <property name="valign">end</property>
-                <property name="vexpand">True</property>
-                <property name="label" translatable="yes">Preference changes only take effect after restarting NoteKit.</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
                 <property name="position">6</property>
               </packing>
             </child>
@@ -244,6 +299,28 @@ This increases startup time and may result in markdown rendering failing if &lt;
             <property name="fill">True</property>
             <property name="position">1</property>
           </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-5">button1</action-widget>
+      <action-widget response="-6">button2</action-widget>
+    </action-widgets>
+    <child type="titlebar">
+      <object class="GtkHeaderBar" id="settings_bar">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="title" translatable="yes">Preferences</property>
+        <property name="subtitle" translatable="yes">Preference changes only take effect after restarting NoteKit.</property>
+        <property name="show_close_button">True</property>
+        <child>
+          <object class="GtkButton" id="reset">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="image">reset_image</property>
+            <property name="always_show_image">True</property>
+          </object>
         </child>
       </object>
     </child>

--- a/data/preferences.glade
+++ b/data/preferences.glade
@@ -311,7 +311,7 @@ This increases startup time and may result in markdown rendering failing if &lt;
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="title" translatable="yes">Preferences</property>
-        <property name="subtitle" translatable="yes">Preference changes only take effect after restarting NoteKit.</property>
+        <property name="subtitle" translatable="yes">Changes only take effect after restarting NoteKit.</property>
         <property name="show_close_button">True</property>
         <child>
           <object class="GtkButton" id="reset">

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -85,10 +85,10 @@ CMainWindow::CMainWindow() : nav_model(), sview()
 	nav.get_style_context()->add_provider(sview_css,GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
 
 	/* load cursor types for document */
-	pen_cursor = Gdk::Cursor::create(Gdk::Display::get_default(),"default");
-	text_cursor = Gdk::Cursor::create(Gdk::Display::get_default(),"text");
-	eraser_cursor = Gdk::Cursor::create(Gdk::Display::get_default(),"cell");
-	selection_cursor = Gdk::Cursor::create(Gdk::Display::get_default(),"cross");
+	pen_cursor = Gdk::Cursor::create(Gdk::Display::get_default(),GetToolCursor("pen", "default"));
+	text_cursor = Gdk::Cursor::create(Gdk::Display::get_default(),GetToolCursor("text", "text"));
+	eraser_cursor = Gdk::Cursor::create(Gdk::Display::get_default(),GetToolCursor("eraser", "cell"));
+	selection_cursor = Gdk::Cursor::create(Gdk::Display::get_default(),GetToolCursor("select", "cross"));
 
 	/* install document view */
 	sbuffer = sview.get_source_buffer();
@@ -580,4 +580,12 @@ bool CMainWindow::on_motion_notify(GdkEventMotion *e)
 	}
 	
 	return false;
+}
+
+std::string CMainWindow::GetToolCursor(std::string tool, std::string fallback) {
+    if(!config["tool"][tool].isString() || config["tool"][tool].asString()=="") {
+        config["tool"][tool]=fallback;
+        return fallback;
+    }
+    return config["tool"][tool].asString();
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -583,9 +583,9 @@ bool CMainWindow::on_motion_notify(GdkEventMotion *e)
 }
 
 std::string CMainWindow::GetToolCursor(std::string tool, std::string fallback) {
-    if(!config["tool"][tool].isString() || config["tool"][tool].asString()=="") {
-        config["tool"][tool]=fallback;
+    if(!config["tool_cursors"][tool].isString() || config["tool_cursors"][tool].asString()=="") {
+        config["tool_cursors"][tool]=fallback;
         return fallback;
     }
-    return config["tool"][tool].asString();
+    return config["tool_cursors"][tool].asString();
 }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -91,6 +91,8 @@ protected:
 		Gtk::SeparatorMenuItem sep;
 		Gtk::CheckMenuItem hide_sidebar;
 	} am;
+
+    std::string GetToolCursor(std::string tool, std::string fallback);
 };
 
 #endif // MAINWINDOW_H


### PR DESCRIPTION
You can now select the cursor notekit uses for a specific tool in the config. Key: root->tool->[text/pen/eraser/select]

And I've improved the Preferences, (the new things are just there graphically, so they are not yet working)
![image](https://user-images.githubusercontent.com/31540351/99190547-64220d00-2767-11eb-9427-b042e1d21097.png)
