### PR TITLE
Remove superfluous <em/>s from the metainfo file

### DIFF
--- a/freedesktop/com.github.blackhole89.notekit.metainfo.xml
+++ b/freedesktop/com.github.blackhole89.notekit.metainfo.xml
@@ -15,7 +15,7 @@
 			digitiser.
 		</p>
 		<p>
-			<em>Why?</em>
+			1. Why?
 		</p>
 		<p>
 			I figured it would be nice to have a free-software,
@@ -31,7 +31,7 @@
 			<li>tablet input</li>
 		</ul>
 		<p>
-			<em>Usage notes</em>
+			2. Usage notes
 		</p>
 		<p>
 			Note management


### PR DESCRIPTION
I forgot two `<em/>`s from the metainfo file. As @bilelmoussaoui pointed out, these are not parsed correctly by the different stores.

Replaced them with `1.` and `2.` to highlight that those are two different sections.