### PR TITLE
Support for cLaTeXMath >= 0.0.3

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -25,9 +25,9 @@ CMainWindow::CMainWindow(const Glib::RefPtr<Gtk::Application>& app) : Gtk::Appli
 	printf("\n");
 	
 	#ifdef HAVE_CLATEXMATH
-	LaTeX::init((data_path+"/data/latex").c_str());
+	tex::LaTeX::init((data_path+"/data/latex").c_str());
 	/* allow \newcommand to override quietly, since we will be rerendering \newcommands unpredictably */
-	TeXRender *r = LaTeX::parse(utf82wide("\\fatalIfCmdConflict{false}"),1,1,1,0);
+	tex::TeXRender *r = tex::LaTeX::parse(tex::utf82wide("\\fatalIfCmdConflict{false}"),1,1,1,0);
 	if(r) delete r;
 	#endif
 	

--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,7 @@ deps = [
 	dependency('jsoncpp'),
 	dependency('zlib'),
 	dependency('fontconfig'),
-	dependency('clatexmath')
+	dependency('clatexmath', version: '>=0.0.3')
 ]
 
 

--- a/pkgs/flatpak/com.github.blackhole89.notekit.yaml
+++ b/pkgs/flatpak/com.github.blackhole89.notekit.yaml
@@ -109,7 +109,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/NanoMichael/cLaTeXMath
-        commit: 81c9d00331ac615128ab39c0c5f0c21887cc2a78
+        commit: d8efee2c435fdb594910ee4c3248c74ab67c831b
         
   - name: notekit
     buildsystem: meson


### PR DESCRIPTION
Added `tex::` in front of classes / functions from cLaTeXMath, as https://github.com/NanoMichael/cLaTeXMath/commit/d8efee2c435fdb594910ee4c3248c74ab67c831b removed the tex namespace to avoid conflicts.

Should close #74 