### PR TITLE
GSV Markdown improvements

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -149,7 +149,7 @@ int mkdirp(std::string dir)
 void CMainWindow::CalculatePaths()
 {
 	char *dbg = getenv("NK_DEVEL");
-	if(dbg || *dbg) {
+	if(dbg != NULL) {
 		fprintf(stderr,"INFO: Debug mode set! Will operate in %s.\n", dbg);
 		data_path=dbg;
 		config_path= data_path + "/notesbase";

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -148,6 +148,15 @@ int mkdirp(std::string dir)
 /* Half-baked interpretation of XDG spec */
 void CMainWindow::CalculatePaths()
 {
+	char *dbg = getenv("NK_DEVEL");
+	if(dbg || *dbg) {
+		fprintf(stderr,"INFO: Debug mode set! Will operate in %s.\n", dbg);
+		data_path=dbg;
+		config_path= data_path + "/notesbase";
+		default_base_path= data_path + "/notesbase";
+		return;
+	}
+
 	char *home = getenv("HOME");
 	if(!home || !*home) {
 		fprintf(stderr,"WARNING: Could not determine user's home directory! Will operate in current working directory.\n");

--- a/sourceview/markdown.lang
+++ b/sourceview/markdown.lang
@@ -184,14 +184,30 @@
         <context ref="line-break"/>
 
         <context ref="latex"/>
+        <context ref="latexml"/>
+        <context ref="escape"/>
 
       </include>
     </context>
-
-    <context id="latex" class="prox latex" style-ref="list-marker">
-      <match>(&#xFFFC;?)(\$\$[^\$]+\$\$|(?&lt;!\$)\$[^\$]+\$)</match>
+    <context id="latex" class="prox latex invisible" style-ref="list-marker">
+      <start>(&#xFFFC;?)(?&lt;![\$\\])\$(?!\$)</start>
+      <end>(?&lt;!\$)\$</end>
       <include>
-        <context sub-pattern="2" class="invisible"/>
+        <context sub-pattern="1" where="start" class-disabled="invisible"/>
+      </include>
+    </context>
+    <context id="latexml" class="prox latex invisible" style-ref="list-marker">
+      <start>(&#xFFFC;?)\$\$(?![\$\\])</start>
+      <end>(?&lt;!\$)\$\$</end>
+      <include>
+        <context sub-pattern="1" where="start" class-disabled="invisible"/>
+      </include>
+    </context>
+
+    <context id="escape" class="prox">
+      <match>(\\)\$</match>
+      <include>
+        <context sub-pattern="1" class="invisible" style-ref="list-marker"/>
       </include>
     </context>
     <!-- Example:
@@ -263,6 +279,8 @@
         <context ref="line-break"/>
 
         <context ref="latex"/>
+        <context ref="latexml"/>
+        <context ref="escape"/>
 
       </include>
     </context>
@@ -488,6 +506,8 @@
         <context ref="line-break"/>
 
         <context ref="latex"/>
+        <context ref="latexml"/>
+        <context ref="escape"/>
 
       </include>
     </context>

--- a/sourceview/markdown.lang
+++ b/sourceview/markdown.lang
@@ -213,13 +213,13 @@
     <!-- Example:
                  <em>HTML code</em> displayed <strong>literally</strong>.
     -->
-    <context id="code-block" class="no-spell-check mono">
+	<!--<context id="code-block" class="no-spell-check mono">
       <match>^( {8,}|\t{2,})([^ \t]+.*)</match>
 
       <include>
         <context sub-pattern="2" style-ref="code"/>
       </include>
-    </context>
+	</context>-->
 
     <!-- Note about following code span contexts: within a paragraph, text
          wrapped with backticks indicates a code span. Markdown allows to use
@@ -487,7 +487,7 @@
         <context ref="setext-header2"/> -->
         <context ref="horizontal-rule"/>
         <context ref="list"/>
-        <context ref="code-block"/>
+			<!--<context ref="code-block"/>-->
         <context ref="1-backtick-code-span"/>
         <context ref="2-backticks-code-span"/>
         <context ref="3-backticks-code-span"/>

--- a/sourceview/markdown.lang
+++ b/sourceview/markdown.lang
@@ -184,7 +184,7 @@
         <context ref="line-break"/>
 
         <context ref="latex"/>
-        <context ref="latexml"/>
+        <context ref="latexc"/>
         <context ref="escape"/>
 
       </include>
@@ -196,7 +196,7 @@
         <context sub-pattern="1" where="start" class-disabled="invisible"/>
       </include>
     </context>
-    <context id="latexml" class="prox latex invisible" style-ref="list-marker">
+    <context id="latexc" class="prox latex invisible" style-ref="list-marker">
       <start>(&#xFFFC;?)\$\$(?![\$\\])</start>
       <end>(?&lt;!\$)\$\$</end>
       <include>
@@ -279,7 +279,7 @@
         <context ref="line-break"/>
 
         <context ref="latex"/>
-        <context ref="latexml"/>
+        <context ref="latexc"/>
         <context ref="escape"/>
 
       </include>
@@ -506,7 +506,7 @@
         <context ref="line-break"/>
 
         <context ref="latex"/>
-        <context ref="latexml"/>
+        <context ref="latexc"/>
         <context ref="escape"/>
 
       </include>

--- a/sourceview/notekit.xml
+++ b/sourceview/notekit.xml
@@ -136,6 +136,9 @@
   <style name="latex:display-math"          foreground="#6A5ACD"/>
   <style name="latex:command"               foreground="#2E8B57" bold="true"/>
   <style name="latex:include"               use-style="def:preprocessor"/>
+  <style name="latexml:display-math"          foreground="#6A5ACD"/>
+  <style name="latexml:command"               foreground="#2E8B57" bold="true"/>
+  <style name="latexml:include"               use-style="def:preprocessor"/>
 
   <style name="sh:variable"                 foreground="#6A5ACD"/>
 

--- a/sourceview/notekit.xml
+++ b/sourceview/notekit.xml
@@ -136,9 +136,9 @@
   <style name="latex:display-math"          foreground="#6A5ACD"/>
   <style name="latex:command"               foreground="#2E8B57" bold="true"/>
   <style name="latex:include"               use-style="def:preprocessor"/>
-  <style name="latexml:display-math"          foreground="#6A5ACD"/>
-  <style name="latexml:command"               foreground="#2E8B57" bold="true"/>
-  <style name="latexml:include"               use-style="def:preprocessor"/>
+  <style name="latexc:display-math"         foreground="#6A5ACD"/>
+  <style name="latexc:command"              foreground="#2E8B57" bold="true"/>
+  <style name="latexc:include"              use-style="def:preprocessor"/>
 
   <style name="sh:variable"                 foreground="#6A5ACD"/>
 


### PR DESCRIPTION
- Multiline LaTeX (closes #72 ) 
- Escaped `\$` now only render as `$` 
- Removed four space/double tab codeblocks ( #32 )

Also added a check for NK_DEVEL env var. If set it'll use the value as notekit root 