### PR TITLE
CI: use gnome image for flatpak

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -7,7 +7,7 @@ jobs:
   flatpak:
     runs-on: ubuntu-20.04
     container:
-      image: docker.io/bilelmoussaoui/flatpak-github-actions
+      image: bilelmoussaoui/flatpak-github-actions:gnome-3.38
       options: --privileged
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
The GNOME image comes with the GNOME SDK pre-installed, should reduce the CI time a bit.