### PR TITLE
CI: use experimental flatpak action

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -11,8 +11,9 @@ jobs:
       options: --privileged
     steps:
     - uses: actions/checkout@v2
-    - uses: bilelmoussaoui/flatpak-github-actions@v2
+    - uses: bilelmoussaoui/flatpak-github-actions@master
       with:
         bundle: "notekit-dev.flatpak"
         manifest-path: "pkgs/flatpak/com.github.blackhole89.notekit.yaml"
         run-tests: "true"
+        cache-key: flatpak-builder-${{ github.sha }}


### PR DESCRIPTION
the @master version contains ccache support, which should reduce the CI time A LOT. It's not released yet, but should work just fine. This is mostly to test it on a project that takes a long time to build.

