### PR TITLE
Adding a meson option to not build with cLaTeXMath

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,29 +4,33 @@ project('notekit', 'cpp',
 )
 
 conf_data = configuration_data()
-conf_data.set('HAVE_CLATEXMATH', true)
 
 deps = [
 	dependency('gtkmm-3.0'),
 	dependency('gtksourceviewmm-3.0'),
 	dependency('jsoncpp'),
 	dependency('zlib'),
-	dependency('fontconfig'),
-	dependency('clatexmath', version: '>=0.0.3')
+	dependency('fontconfig')
 ]
 
+if get_option('clatexmath')
+	deps += dependency('clatexmath', version: '>=0.0.3')
+	conf_data.set('HAVE_CLATEXMATH', true)
+endif
 
 configure_file(input : 'config.h.meson.in',
 	output : 'config.h',
 	configuration : conf_data
 )
 
-
 subdir('freedesktop')
 
 install_subdir('data/', install_dir: get_option('datadir')/'notekit')
 install_subdir('sourceview/', install_dir: get_option('datadir')/'notekit')
-meson.add_install_script('symlink-clatexmath.sh')
+
+#if get_option('clatexmath')
+#	meson.add_install_script('symlink-clatexmath.sh')
+#endif
 
 executable('notekit',
 	'drawing.cpp',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('clatexmath', type : 'boolean', value : true, description : 'Use cLaTeXMath')


### PR DESCRIPTION
Hello :)!

I am trying for _months_ now to get NoteKit into the Fedora repositories... in vain... cLaTeXMath has some licensing issues which makes it impossible to get it there (GPL violation, opaque font licenses, etc...). After waiting for quite a time, I have decided to just remove temporarily cLaTeXMath as a dependency. This patch allows someone to use the meson build system while disabling clatexmath (more details in the commit message).

I'd be happy if @sp1ritCS could also take a look since he is the one which introduced this new build system :)!

Note: This patch does not hopefully break builds using meson, as it defaults to using cLaTeXMath.