### PR TITLE
fix break change for cLaTeXMath library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,12 @@ if (HAVE_CLATEXMATH)
     include_directories("${CLATEXMATH_PATH}/src/")
     set (LATEX_COMMENT_START "")
     set (LATEX_COMMENT_END "")
+    find_package(PkgConfig)
+    # due to
+    # https://github.com/NanoMichael/cLaTeXMath/pull/68
+    # https://github.com/NanoMichael/cLaTeXMath/pull/70
+    # we have to link tinyxml2 manually now
+    pkg_check_modules(tinyxml2 tinyxml2)
 endif (HAVE_CLATEXMATH)
 
 configure_file (
@@ -161,7 +167,7 @@ if (HAVE_LASEM)
 endif (HAVE_LASEM)
 
 if (HAVE_CLATEXMATH)
-    set(LINK_OPTIONS -L${CLATEXMATH_PATH}/ -l:libclatexmath.a ${LINK_OPTIONS})
+    set(LINK_OPTIONS -L${CLATEXMATH_PATH}/ -l:libLaTeX.a -l${tinyxml2_LIBRARIES} ${LINK_OPTIONS})
 endif (HAVE_CLATEXMATH)
 #}}}}
 

--- a/install-clatexmath.sh
+++ b/install-clatexmath.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 git clone https://github.com/NanoMichael/cLaTeXMath.git
 cd cLaTeXMath
-git reset --hard 7cbc0b9e4185da3a7f633473a794ee1ef7b371e8
-echo 'add_library(clatexmath STATIC ${SRC})' >> CMakeLists.txt
+git reset --hard HEAD
 cmake -DCMAKE_BUILD_TYPE=Release -DHAVE_LOG=OFF -DGRAPHICS_DEBUG=OFF .
 make
 cp -r res ../data/latex
- 


### PR DESCRIPTION
see
https://github.com/NanoMichael/cLaTeXMath/commit/0359f830d381e400d9941436c63c2ecfe8c197a7#commitcomment-50769555
https://github.com/NanoMichael/cLaTeXMath/pull/68
https://github.com/NanoMichael/cLaTeXMath/pull/70

for cmake, i perfer target-based style.
If possible, I can give a PR that rewrites cmake build files with target-based style.
e.g. https://github.com/NanoMichael/cLaTeXMath/commit/0359f830d381e400d9941436c63c2ecfe8c197a7