### PR TITLE
Fixed linuxbrew CI script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,9 +120,21 @@ jobs:
       - name: Patch NoteKit 🩹
         run: patch -p1 < Apple/llvm.patch
       - name: Configure 🔧
+        if: ${{ matrix.os.triplet == 'x86_64-apple-darwin' }}
         run: meson ${{ matrix.os.triplet }}
       - name: Compile 🎲
+        if: ${{ matrix.os.triplet == 'x86_64-apple-darwin' }}
         run: ninja -C ${{ matrix.os.triplet }}
+      - name: Build in Brew shell 🧮
+        if: ${{ matrix.os.triplet == 'x86_64-linux-gnu' }}
+        run: |
+          brew sh <<EOF
+            export HOMEBREW_CC=$(brew list gcc | grep "/bin/gcc-[0-9]*$" | head -n1)
+            export HOMEBREW_CXX=$(brew list gcc | grep "/bin/g++-[0-9]*$" | head -n1)
+            meson ${{ matrix.os.triplet }}
+            $(brew list ninja | grep "bin/ninja$" | head -n1) -C ${{ matrix.os.triplet }}
+            exit
+          EOF
       - name: Compress build artifacts 📦
         run: |
           pushd ${{ matrix.os.triplet }}


### PR DESCRIPTION
Regarding the comment you made on #121 , this should fix the Drawin failure. The MinGW failure was just a package mirror failure.

The current linking failures occur, because clatexmath is build by brew with it's version of gcc. Brew tends to ship a fairly new version, including versions of gcc adjacent libraries like libstdc++.

The issue was, that the "out-of-brew" notekit build made meson prefer the outdated systems compiler and libstdc++. And since a library linked against libstdc++ is not backward compatible with a older version, it failed to compile.

With this patch, it'll use brews compiler for building notekit and thus it should work.