### PR TITLE
Enhance code block behaviour

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ execute_process(COMMAND
     OUTPUT_VARIABLE
     CL_TMP_VAR
     OUTPUT_STRIP_TRAILING_WHITESPACE)
-string(STRIP ${CL_TMP_VAR} CL_VAR_3)
+string(STRIP "${CL_TMP_VAR}" CL_VAR_3)
 execute_process(COMMAND 
     pkg-config --cflags fontconfig
     OUTPUT_VARIABLE

--- a/notebook_highlight.hpp
+++ b/notebook_highlight.hpp
@@ -41,11 +41,22 @@ std::string CNotebook::GetHighlightProxyDir()
 		           "  </context>\n");
 	}
 	
+	/* and one context to fallback when language not found */
+	fprintf(fl,"  <context id=\"proxy-fallback\" class=\"no-spell-check mono\" style-ref=\"markdown:code\">\n"
+			   "   <start>^(```)(.*)$</start>\n"
+			   "   <end>^(```)$</end>\n"
+			   "   <include>\n"
+			   "     <context sub-pattern=\"1\" where=\"start\" style-ref=\"markdown:tag\" class=\"hline\" />\n"
+			   "     <context sub-pattern=\"1\" where=\"end\" style-ref=\"markdown:tag\" class=\"hline\" />\n"
+			   "   </include>\n"
+	           "  </context>\n");
+	
 	/* finally, export every context as part of this "language" */
 	fprintf(fl,"  <context id=\"markdownlisting\">\n   <include>\n");
 	for(std::string &l : langs_supported) {
 		fprintf(fl,"    <context ref=\"proxy-%s\"/>\n",l.c_str());
 	}
+	fprintf(fl,"    <context ref=\"proxy-fallback\"/>\n");
 	fprintf(fl,"   </include>\n  </context>");
 	
 	fprintf(fl," </definitions>\n</language>\n");

--- a/notebook_highlight.hpp
+++ b/notebook_highlight.hpp
@@ -36,6 +36,7 @@ std::string CNotebook::GetHighlightProxyDir()
 		fprintf(fl,"    <include>\n     <context ref=\"%s:%s\" />\n    </include>\n",l.c_str(),l.c_str());
 		fprintf(fl,"    </context>\n"
 				   "    <context sub-pattern=\"1\" where=\"start\" style-ref=\"markdown:tag\" class=\"hline\" />\n"
+				   "    <context sub-pattern=\"2\" where=\"start\" style-ref=\"def:statement\" />\n"
 				   "    <context sub-pattern=\"1\" where=\"end\" style-ref=\"markdown:tag\" class=\"hline\" />\n"
 				   "   </include>\n"
 		           "  </context>\n");
@@ -43,10 +44,11 @@ std::string CNotebook::GetHighlightProxyDir()
 	
 	/* and one context to fallback when language not found */
 	fprintf(fl,"  <context id=\"proxy-fallback\" class=\"no-spell-check mono\" style-ref=\"markdown:code\">\n"
-			   "   <start>^(```)(.*)$</start>\n"
+			   "   <start>^(```\\s*)(.*)$</start>\n"
 			   "   <end>^(```)$</end>\n"
 			   "   <include>\n"
 			   "     <context sub-pattern=\"1\" where=\"start\" style-ref=\"markdown:tag\" class=\"hline\" />\n"
+			   "     <context sub-pattern=\"2\" where=\"start\" style-ref=\"def:statement\" />\n"
 			   "     <context sub-pattern=\"1\" where=\"end\" style-ref=\"markdown:tag\" class=\"hline\" />\n"
 			   "   </include>\n"
 	           "  </context>\n");

--- a/notebook_highlight.hpp
+++ b/notebook_highlight.hpp
@@ -52,4 +52,5 @@ std::string CNotebook::GetHighlightProxyDir()
 	
 	fclose(fl);
 	
-	return "/tmp/notekit.gsv";}
+	return "/tmp/notekit.gsv";
+}

--- a/notebook_highlight.hpp
+++ b/notebook_highlight.hpp
@@ -29,7 +29,7 @@ std::string CNotebook::GetHighlightProxyDir()
 	/* one context for every language detected */
 	for(std::string &l : langs_supported) {
 		fprintf(fl,"  <context id=\"proxy-%s\" class=\"no-spell-check mono\">\n",l.c_str());
-		fprintf(fl,"   <start>^(```%s)$</start>\n",l.c_str());
+		fprintf(fl,"   <start>^(```\\s*)(%s(\\s.*)?)$</start>\n",l.c_str());
 		fprintf(fl,"   <end>^(```)$</end>\n");
 		fprintf(fl,"   <include>\n    <context id=\"proxy-%s-contents\" extend-parent=\"false\">\n",l.c_str());
 		fprintf(fl,"    <start></start>\n");


### PR DESCRIPTION
Fix issue I've opened https://github.com/blackhole89/notekit/issues/127

TLDR:
Allow spaces between \`\`\` and  language name 
Fallback to Markdown code block style when written unrecognized language