### PR TITLE
mainwindow: gated gdk_wayland_* calls behind version check

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -793,6 +793,7 @@ void CMainWindow::SettingCsdUpdate() {
 	 * unable to change the decorations after it's initial set, so
 	 * NoteKit had to be restarted in order to have proper decorations.
 	 */
+	#if GTK_CHECK_VERSION (3,24,0)
 	#ifdef GDK_WINDOWING_WAYLAND
 		if (GDK_IS_WAYLAND_DISPLAY (gdk_window_get_display(window))) {
 			if (state) {
@@ -801,6 +802,7 @@ void CMainWindow::SettingCsdUpdate() {
 				gdk_wayland_window_announce_ssd(window);
 			}
 		}
+	#endif
 	#endif
 	/*
 	 * TODO: here is space for potential support of broadway, w32 & quartz:


### PR DESCRIPTION
This should ensure that NoteKit will continue to be build on RHEL 8, as this currently fails with:
```
[   99s] ../mainwindow.cpp: In member function â€˜void CMainWindow::SettingCsdUpdate()â€™:
[   99s] ../mainwindow.cpp:801:5: error: â€˜gdk_wayland_window_announce_ssdâ€™ was not declared in this scope
[   99s]      gdk_wayland_window_announce_ssd(window);
[   99s]      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[   99s] ../mainwindow.cpp:801:5: note: suggested alternative: â€˜gdk_wayland_window_announce_csdâ€™
[   99s]      gdk_wayland_window_announce_ssd(window);
[   99s]      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[   99s]      gdk_wayland_window_announce_csd
```